### PR TITLE
added refresh token support

### DIFF
--- a/backend/DevUp/DevUp.Api/DevUp.Api.csproj
+++ b/backend/DevUp/DevUp.Api/DevUp.Api.csproj
@@ -7,6 +7,7 @@
     <UserSecretsId>35c044d2-112e-409c-9731-78e08382be6e</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/backend/DevUp/DevUp.Api/V1/Controllers/Identity/Requests/DeviceRequest.cs
+++ b/backend/DevUp/DevUp.Api/V1/Controllers/Identity/Requests/DeviceRequest.cs
@@ -1,0 +1,10 @@
+﻿namespace DevUp.Api.V1.Controllers.Identity.Requests
+{
+    public class DeviceRequest
+    {
+        /// <example>b691b7a8-b251-4b11-8034-f3a0a154dffe</example>
+        public string Id { get; init; }
+        /// <example>iPhone (John)</example>
+        public string Name { get; init; }
+    }
+}

--- a/backend/DevUp/DevUp.Api/V1/Controllers/Identity/Requests/LoginUserRequest.cs
+++ b/backend/DevUp/DevUp.Api/V1/Controllers/Identity/Requests/LoginUserRequest.cs
@@ -2,7 +2,13 @@
 {
     public class LoginUserRequest
     {
-        public string Username { get; set; }
-        public string Password { get; set; }
+        /// <summary>
+        /// Username
+        /// </summary>
+        /// <example>john-cena</example>
+        public string Username { get; init; }
+        /// <example>s3cUr3-p4s$</example>
+        public string Password { get; init; }
+        public DeviceRequest Device { get; init; }
     }
 }

--- a/backend/DevUp/DevUp.Api/V1/Controllers/Identity/Requests/RefreshUserRequest.cs
+++ b/backend/DevUp/DevUp.Api/V1/Controllers/Identity/Requests/RefreshUserRequest.cs
@@ -1,0 +1,9 @@
+﻿namespace DevUp.Api.V1.Controllers.Identity.Requests
+{
+    public class RefreshUserRequest
+    {
+        public string Token { get; init; }
+        public string RefreshToken { get; init; }
+        public DeviceRequest Device { get; init; }
+    }
+}

--- a/backend/DevUp/DevUp.Api/V1/Controllers/Identity/Requests/RegisterUserRequest.cs
+++ b/backend/DevUp/DevUp.Api/V1/Controllers/Identity/Requests/RegisterUserRequest.cs
@@ -2,7 +2,10 @@
 {
     public class RegisterUserRequest
     {
-        public string Username { get; set; }
-        public string Password { get; set; }
+        /// <example>john-cena</example>
+        public string Username { get; init; }
+        /// <example>s3cUr3-p4s$</example>
+        public string Password { get; init; }
+        public DeviceRequest Device { get; init; }
     }
 }

--- a/backend/DevUp/DevUp.Api/V1/Controllers/Identity/Responses/FailedResponse.cs
+++ b/backend/DevUp/DevUp.Api/V1/Controllers/Identity/Responses/FailedResponse.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace DevUp.Api.V1.Controllers.Identity.Responses
+{
+    public abstract class FailedResponse
+    {
+        public IEnumerable<string> Errors { get; init; }
+    }
+}

--- a/backend/DevUp/DevUp.Api/V1/Controllers/Identity/Responses/LoginSucceededResponse.cs
+++ b/backend/DevUp/DevUp.Api/V1/Controllers/Identity/Responses/LoginSucceededResponse.cs
@@ -1,7 +1,6 @@
 ﻿namespace DevUp.Api.V1.Controllers.Identity.Responses
 {
-    public class LoginSucceededResponse
+    public class LoginSucceededResponse : SucceededResponse
     {
-        public string Token { get; init; }
     }
 }

--- a/backend/DevUp/DevUp.Api/V1/Controllers/Identity/Responses/RefreshFailedResponse.cs
+++ b/backend/DevUp/DevUp.Api/V1/Controllers/Identity/Responses/RefreshFailedResponse.cs
@@ -1,6 +1,6 @@
 ﻿namespace DevUp.Api.V1.Controllers.Identity.Responses
 {
-    public class LoginFailedResponse : FailedResponse
+    public class RefreshFailedResponse : FailedResponse
     {
     }
 }

--- a/backend/DevUp/DevUp.Api/V1/Controllers/Identity/Responses/RefreshSucceededResponse.cs
+++ b/backend/DevUp/DevUp.Api/V1/Controllers/Identity/Responses/RefreshSucceededResponse.cs
@@ -1,6 +1,6 @@
 ﻿namespace DevUp.Api.V1.Controllers.Identity.Responses
 {
-    public class LoginFailedResponse : FailedResponse
+    public class RefreshSucceededResponse : SucceededResponse
     {
     }
 }

--- a/backend/DevUp/DevUp.Api/V1/Controllers/Identity/Responses/RegistrationFailedResponse.cs
+++ b/backend/DevUp/DevUp.Api/V1/Controllers/Identity/Responses/RegistrationFailedResponse.cs
@@ -1,9 +1,6 @@
-﻿using System.Collections.Generic;
-
-namespace DevUp.Api.V1.Controllers.Identity.Responses
+﻿namespace DevUp.Api.V1.Controllers.Identity.Responses
 {
-    public class RegistrationFailedResponse
+    public class RegistrationFailedResponse : FailedResponse
     {
-        public IEnumerable<string> Errors { get; init; }
     }
 }

--- a/backend/DevUp/DevUp.Api/V1/Controllers/Identity/Responses/RegistrationSucceededResponse.cs
+++ b/backend/DevUp/DevUp.Api/V1/Controllers/Identity/Responses/RegistrationSucceededResponse.cs
@@ -1,7 +1,6 @@
 ﻿namespace DevUp.Api.V1.Controllers.Identity.Responses
 {
-    public class RegistrationSucceededResponse
+    public class RegistrationSucceededResponse : SucceededResponse
     {
-        public string Token { get; init; }
     }
 }

--- a/backend/DevUp/DevUp.Api/V1/Controllers/Identity/Responses/SucceededResponse.cs
+++ b/backend/DevUp/DevUp.Api/V1/Controllers/Identity/Responses/SucceededResponse.cs
@@ -1,0 +1,8 @@
+﻿namespace DevUp.Api.V1.Controllers.Identity.Responses
+{
+    public abstract class SucceededResponse
+    {
+        public string Token { get; init; }
+        public string RefreshToken { get; init; }
+    }
+}

--- a/backend/DevUp/DevUp.Domain/Identity/Exceptions/IdentityException.cs
+++ b/backend/DevUp/DevUp.Domain/Identity/Exceptions/IdentityException.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace DevUp.Domain.Identity.Exceptions
+{
+    public abstract class IdentityException : Exception
+    {
+        public IEnumerable<string> Errors { get; }
+
+        public IdentityException(IEnumerable<string> errors)
+        {
+            Errors = errors;
+        }
+    }
+}

--- a/backend/DevUp/DevUp.Domain/Identity/Exceptions/RefreshFailedException.cs
+++ b/backend/DevUp/DevUp.Domain/Identity/Exceptions/RefreshFailedException.cs
@@ -2,9 +2,9 @@
 
 namespace DevUp.Domain.Identity.Exceptions
 {
-    public class LoginFailedException : IdentityException
+    public class RefreshFailedException : IdentityException
     {
-        public LoginFailedException(IEnumerable<string> errors) 
+        public RefreshFailedException(IEnumerable<string> errors) 
             : base(errors)
         {
         }

--- a/backend/DevUp/DevUp.Domain/Identity/Exceptions/RegistrationFailedException.cs
+++ b/backend/DevUp/DevUp.Domain/Identity/Exceptions/RegistrationFailedException.cs
@@ -1,15 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace DevUp.Domain.Identity.Exceptions
 {
-    public class RegistrationFailedException : Exception
+    public class RegistrationFailedException
+        : IdentityException
     {
-        public IEnumerable<string> Errors { get; }
-
-        public RegistrationFailedException(IEnumerable<string> errors)
+        public RegistrationFailedException(IEnumerable<string> errors) 
+            : base(errors)
         {
-            Errors = errors;
         }
     }
 }

--- a/backend/DevUp/DevUp.Domain/Identity/IIdentityService.cs
+++ b/backend/DevUp/DevUp.Domain/Identity/IIdentityService.cs
@@ -1,27 +1,19 @@
 ﻿using System.Threading.Tasks;
 using DevUp.Domain.Identity.Exceptions;
 using DevUp.Domain.Identity.Results;
+using DevUp.Domain.Machine.Entities;
 
 namespace DevUp.Domain.Identity
 {
     public interface IIdentityService
     {
-        /// <summary>
-        /// Registers an user
-        /// </summary>
-        /// <param name="username">Username</param>
-        /// <param name="password">Password</param>
-        /// <returns>Authentication token</returns>
         /// <exception cref="RegistrationFailedException"/>
-        public Task<RegistrationResult> RegisterAsync(string username, string password);
+        public Task<IRegistrationResult> RegisterAsync(string username, string password, Device device);
 
-        /// <summary>
-        /// Logs in an user
-        /// </summary>
-        /// <param name="username">Username</param>
-        /// <param name="password">Password</param>
-        /// <returns>Authentication token</returns>
         /// <exception cref="LoginFailedException"/>
-        public Task<LoginResult> LoginAsync(string username, string password);
+        public Task<ILoginResult> LoginAsync(string username, string password, Device device);
+
+        /// <exception cref="RefreshFailedException"/>
+        public Task<IRefreshResult> RefreshAsync(string token, string refreshToken, Device device);
     }
 }

--- a/backend/DevUp/DevUp.Domain/Identity/Results/ILoginResult.cs
+++ b/backend/DevUp/DevUp.Domain/Identity/Results/ILoginResult.cs
@@ -1,6 +1,6 @@
 ﻿namespace DevUp.Domain.Identity.Results
 {
-    public abstract class RegistrationResult
+    public interface ILoginResult
     {
     }
 }

--- a/backend/DevUp/DevUp.Domain/Identity/Results/IRefreshResult.cs
+++ b/backend/DevUp/DevUp.Domain/Identity/Results/IRefreshResult.cs
@@ -1,6 +1,6 @@
 ﻿namespace DevUp.Domain.Identity.Results
 {
-    public abstract class LoginResult
+    public interface IRefreshResult
     {
     }
 }

--- a/backend/DevUp/DevUp.Domain/Identity/Results/IRegistrationResult.cs
+++ b/backend/DevUp/DevUp.Domain/Identity/Results/IRegistrationResult.cs
@@ -1,0 +1,6 @@
+﻿namespace DevUp.Domain.Identity.Results
+{
+    public interface IRegistrationResult
+    {
+    }
+}

--- a/backend/DevUp/DevUp.Domain/Machine/Entities/Device.cs
+++ b/backend/DevUp/DevUp.Domain/Machine/Entities/Device.cs
@@ -1,0 +1,15 @@
+﻿using DevUp.Domain.Entities;
+
+namespace DevUp.Domain.Machine.Entities
+{
+    public class Device : Entity<DeviceId>
+    {
+        public string Name { get; }
+
+        public Device(DeviceId id, string name) 
+            : base(id)
+        {
+            Name = name;
+        }
+    }
+}

--- a/backend/DevUp/DevUp.Domain/Machine/Entities/DeviceId.cs
+++ b/backend/DevUp/DevUp.Domain/Machine/Entities/DeviceId.cs
@@ -1,0 +1,24 @@
+﻿using DevUp.Domain.Entities;
+
+namespace DevUp.Domain.Machine.Entities
+{
+    public class DeviceId : EntityId
+    {
+        public string Id { get; }
+
+        public DeviceId(string id)
+        {
+            Id = id;
+        }
+
+        public override bool Equals(EntityId other)
+        {
+            return other is DeviceId deviceId && Id == deviceId.Id;
+        }
+
+        public override int GetHashCode()
+        {
+            return Id.GetHashCode();
+        }
+    }
+}

--- a/backend/DevUp/DevUp.Infrastructure.Postgres/JwtIdentity/Dtos/DeviceDto.cs
+++ b/backend/DevUp/DevUp.Infrastructure.Postgres/JwtIdentity/Dtos/DeviceDto.cs
@@ -1,0 +1,8 @@
+﻿namespace DevUp.Infrastructure.Postgres.JwtIdentity.Dtos
+{
+    internal class DeviceDto
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/backend/DevUp/DevUp.Infrastructure.Postgres/JwtIdentity/Dtos/RefreshTokenDto.cs
+++ b/backend/DevUp/DevUp.Infrastructure.Postgres/JwtIdentity/Dtos/RefreshTokenDto.cs
@@ -1,0 +1,14 @@
+﻿namespace DevUp.Infrastructure.Postgres.JwtIdentity.Dtos
+{
+    internal class RefreshTokenDto
+    {
+        public string Token { get; set; }
+        public string Jti { get; set; }
+        public Guid UserId { get; set; }
+        public DateTime CreationDate { get; set; }
+        public DateTime ExpiryDate { get; set; }
+        public DeviceDto Device { get; set; }
+        public bool Used { get; set; }
+        public bool Invalidated { get; set; }
+    }
+}

--- a/backend/DevUp/DevUp.Infrastructure.Postgres/JwtIdentity/JwtIdentityInstaller.cs
+++ b/backend/DevUp/DevUp.Infrastructure.Postgres/JwtIdentity/JwtIdentityInstaller.cs
@@ -16,7 +16,20 @@ namespace DevUp.Infrastructure.Postgres.JwtIdentity
             var jwtSettings = new JwtSettings();
             services.AddSingleton(jwtSettings);
             services.AddTransient<IIdentityService, JwtIdentityService>();
+            services.AddTransient<IRefreshTokenStore, RefreshTokenStore>();
             services.AddPostgresUserManager();
+
+            var tokenValidationParameters = new TokenValidationParameters()
+            {
+                ValidateIssuerSigningKey = true,
+                IssuerSigningKey = new SymmetricSecurityKey(jwtSettings.Secret),
+                ValidateIssuer = false,
+                ValidateAudience = false,
+                RequireExpirationTime = false,
+                ValidateLifetime = true,
+            };
+
+            services.AddSingleton(tokenValidationParameters);
 
             services.AddAuthentication(opts =>
             {
@@ -26,15 +39,7 @@ namespace DevUp.Infrastructure.Postgres.JwtIdentity
             }).AddJwtBearer(opts =>
             {
                 opts.SaveToken = true;
-                opts.TokenValidationParameters = new()
-                {
-                    ValidateIssuerSigningKey = true,
-                    IssuerSigningKey = new SymmetricSecurityKey(jwtSettings.Secret),
-                    ValidateIssuer = false,
-                    ValidateAudience = false,
-                    RequireExpirationTime = false,
-                    ValidateLifetime = true,
-                };
+                opts.TokenValidationParameters = tokenValidationParameters;
             });
 
             return services;

--- a/backend/DevUp/DevUp.Infrastructure.Postgres/JwtIdentity/JwtIdentityService.cs
+++ b/backend/DevUp/DevUp.Infrastructure.Postgres/JwtIdentity/JwtIdentityService.cs
@@ -1,10 +1,13 @@
 ﻿using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using System.Security.Cryptography;
 using DevUp.Domain.Identity;
 using DevUp.Domain.Identity.Exceptions;
 using DevUp.Domain.Identity.Results;
+using DevUp.Domain.Machine.Entities;
 using DevUp.Infrastructure.Postgres.JwtIdentity.Dtos;
 using DevUp.Infrastructure.Postgres.JwtIdentity.Results;
+using DevUp.Infrastructure.Postgres.JwtIdentity.Stores;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.IdentityModel.Tokens;
 
@@ -12,16 +15,22 @@ namespace DevUp.Infrastructure.Postgres.JwtIdentity
 {
     internal class JwtIdentityService : IIdentityService
     {
+        private const string SecurityAlghoritm = SecurityAlgorithms.HmacSha256;
+
         private readonly UserManager<UserDto> _userManager;
         private readonly JwtSettings _jwtSettings;
+        private readonly TokenValidationParameters _tokenValidationParameters;
+        private readonly IRefreshTokenStore _refreshTokenStore;
 
-        public JwtIdentityService(UserManager<UserDto> userManager, JwtSettings jwtSettings)
+        public JwtIdentityService(UserManager<UserDto> userManager, JwtSettings jwtSettings, TokenValidationParameters tokenValidationParameters, IRefreshTokenStore refreshTokenStore)
         {
             _userManager = userManager ?? throw new ArgumentNullException(nameof(userManager));
-            _jwtSettings = jwtSettings;
+            _jwtSettings = jwtSettings ?? throw new ArgumentNullException(nameof(jwtSettings));
+            _tokenValidationParameters = tokenValidationParameters ?? throw new ArgumentNullException(nameof(tokenValidationParameters));
+            _refreshTokenStore = refreshTokenStore ?? throw new ArgumentNullException(nameof(refreshTokenStore));
         }
 
-        public async Task<RegistrationResult> RegisterAsync(string username, string password)
+        public async Task<IRegistrationResult> RegisterAsync(string username, string password, Device device)
         {
             var existingUser = await _userManager.FindByNameAsync(username);
             if (existingUser is not null)
@@ -32,11 +41,17 @@ namespace DevUp.Infrastructure.Postgres.JwtIdentity
             if (!createdUser.Succeeded)
                 throw new RegistrationFailedException(createdUser.Errors.Select(e => e.Description));
 
-            var token = GenerateJwtToken(user);
-            return new JwtRegistrationResult() { Token = token };
+            var tokenHandler = new JwtSecurityTokenHandler();
+            var token = GenerateToken(tokenHandler, user);
+            var refreshTokenDto = GenerateRefreshTokenDto(token, user, device);
+            var createdRefreshToken = await _refreshTokenStore.CreateAsync(refreshTokenDto, CancellationToken.None);
+            if (!createdRefreshToken.Succeeded)
+                throw new RegistrationFailedException(createdRefreshToken.Errors.Select(e => e.Description));
+
+            return new JwtRegistrationResult() { Token = tokenHandler.WriteToken(token), RefreshToken = refreshTokenDto.Token };
         }
 
-        public async Task<LoginResult> LoginAsync(string username, string password)
+        public async Task<ILoginResult> LoginAsync(string username, string password, Device device)
         {
             var user = await _userManager.FindByNameAsync(username);
             if (user is null)
@@ -46,28 +61,140 @@ namespace DevUp.Infrastructure.Postgres.JwtIdentity
             if (!isPasswordValid)
                 throw new LoginFailedException(new[] { "Invalid password." });
 
-            var token = GenerateJwtToken(user);
-            return new JwtLoginResult() { Token = token };
+            var tokenHandler = new JwtSecurityTokenHandler();
+            var token = GenerateToken(tokenHandler, user);
+            var refreshTokenDto = GenerateRefreshTokenDto(token, user, device);
+            var createdRefreshToken = await _refreshTokenStore.CreateAsync(refreshTokenDto, CancellationToken.None);
+            if (!createdRefreshToken.Succeeded)
+                throw new LoginFailedException(createdRefreshToken.Errors.Select(e => e.Description));
+
+            return new JwtLoginResult() { Token = tokenHandler.WriteToken(token), RefreshToken = refreshTokenDto.Token };
         }
 
-        private string GenerateJwtToken(UserDto user)
+        public async Task<IRefreshResult> RefreshAsync(string token, string refreshToken, Device device)
         {
+            var principal = GetPrincipal(token);
+            if (principal is null)
+                throw new RefreshFailedException(new[] { "Token is invalid." });
+
+            var refreshTokenDto = await _refreshTokenStore.GetAsync(refreshToken, CancellationToken.None);
+            if (refreshTokenDto is null)
+                throw new RefreshFailedException(new[] { "Refresh token does not exist." });
+
+            var username = principal.FindFirstValue("username");
+            var user = await _userManager.FindByNameAsync(username);
+            if (user is null)
+                throw new RefreshFailedException(new[] { "Token did not contain username of an existing user." });
+
+            ValidateTokens(user, principal, refreshTokenDto, device);
+
+            var markedAsUsed = await _refreshTokenStore.MarkAsUsed(refreshTokenDto, CancellationToken.None);
+            if (!markedAsUsed.Succeeded)
+                throw new RefreshFailedException(markedAsUsed.Errors.Select(e => e.Description));
+
             var tokenHandler = new JwtSecurityTokenHandler();
+            var newToken = GenerateToken(tokenHandler, user);
+            var newRefreshTokenDto = GenerateRefreshTokenDto(newToken, user, device);
+            var createdRefreshToken = await _refreshTokenStore.CreateAsync(newRefreshTokenDto, CancellationToken.None);
+            if (!createdRefreshToken.Succeeded)
+                throw new LoginFailedException(createdRefreshToken.Errors.Select(e => e.Description));
+
+            return new JwtRefreshResult() { Token = tokenHandler.WriteToken(newToken), RefreshToken = newRefreshTokenDto.Token };
+        }
+
+        private SecurityToken GenerateToken(JwtSecurityTokenHandler tokenHandler, UserDto user)
+        {
             var tokenDescriptor = new SecurityTokenDescriptor()
             {
                 Subject = new ClaimsIdentity(GetClaims(user.UserName)),
-                Expires = DateTime.UtcNow.AddMilliseconds(_jwtSettings.ExpiryMs),
-                SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(_jwtSettings.Secret), SecurityAlgorithms.HmacSha256Signature)
+                Expires = DateTime.UtcNow.AddMilliseconds(_jwtSettings.JwtExpiryMs),
+                SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(_jwtSettings.Secret), SecurityAlghoritm)
             };
 
-            var token = tokenHandler.CreateToken(tokenDescriptor);
-            return tokenHandler.WriteToken(token);
+            return tokenHandler.CreateToken(tokenDescriptor);
+        }
+
+        private RefreshTokenDto GenerateRefreshTokenDto(SecurityToken token, UserDto user, Device device)
+        {
+            var now = DateTime.UtcNow;
+            return new RefreshTokenDto()
+            {
+                Token = GenerateRefreshToken(),
+                Jti = token.Id,
+                UserId = user.Id,
+                CreationDate = now,
+                ExpiryDate = now.AddMilliseconds(_jwtSettings.JwtRefreshExpiryMs),
+                Device = new DeviceDto() 
+                {
+                    Id = device.Id.Id,
+                    Name = device.Name
+                },
+                Used = false,
+                Invalidated = false,
+            };
+        }
+
+        private static string GenerateRefreshToken()
+        {
+            var randomNumber = new byte[64];
+            using var generator = RandomNumberGenerator.Create();
+            generator.GetBytes(randomNumber);
+            return Convert.ToBase64String(randomNumber);
         }
 
         private static IEnumerable<Claim> GetClaims(string username)
         {
-            yield return new Claim(JwtRegisteredClaimNames.Sub, username);
+            yield return new Claim("username", username);
             yield return new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString());
+        }
+
+        private ClaimsPrincipal? GetPrincipal(string token)
+        {
+            var tokenHandler = new JwtSecurityTokenHandler();
+
+            try
+            {
+                var principal = tokenHandler.ValidateToken(token, _tokenValidationParameters, out var validatedToken);
+                if (validatedToken is not JwtSecurityToken jwtSecurityToken)
+                    return null;
+                if (!SecurityAlghoritm.Equals(jwtSecurityToken.Header.Alg, StringComparison.InvariantCultureIgnoreCase))
+                    return null;
+
+                return principal;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private void ValidateTokens(UserDto user, ClaimsPrincipal principal, RefreshTokenDto refreshToken, Device device)
+        {
+            static bool Equals(string s1, string s2) => s1 is not null && string.Equals(s1, s2, StringComparison.InvariantCulture);
+
+            var expiryDateUnix = long.Parse(principal.FindFirstValue(JwtRegisteredClaimNames.Exp));
+            var expiryDate = DateTimeOffset.FromUnixTimeSeconds(expiryDateUnix).UtcDateTime;
+            if (expiryDate > DateTime.UtcNow)
+                throw new RefreshFailedException(new[] { "Token has not expired yet." });
+
+            if (refreshToken.ExpiryDate < DateTime.UtcNow)
+                throw new RefreshFailedException(new[] { "Refresh token has expired." });
+
+            if (refreshToken.Invalidated)
+                throw new RefreshFailedException(new[] { "Refresh token has been invalidated." });
+
+            if (refreshToken.Used)
+                throw new RefreshFailedException(new[] { "Refresh token has been used already." });
+
+            var jti = principal.Claims.Single(c => c.Type == JwtRegisteredClaimNames.Jti).Value;
+            if (!Equals(jti, refreshToken.Jti))
+                throw new RefreshFailedException(new[] { "Refresh token does not belong to this token." });
+
+            if (refreshToken.UserId != user.Id)
+                throw new RefreshFailedException(new[] { "Refresh token does not belong to this user." });
+
+            if (!Equals(refreshToken.Device.Id, device.Id.Id))
+                throw new RefreshFailedException(new[] { "Refresh token does not belong to this device." });
         }
     }
 }

--- a/backend/DevUp/DevUp.Infrastructure.Postgres/JwtIdentity/JwtSettings.cs
+++ b/backend/DevUp/DevUp.Infrastructure.Postgres/JwtIdentity/JwtSettings.cs
@@ -6,19 +6,25 @@ namespace DevUp.Infrastructure.Postgres.JwtIdentity
     internal class JwtSettings
     {
         public byte[] Secret { get; }
-        public int ExpiryMs { get; }
+        public int JwtExpiryMs { get; }
+        public int JwtRefreshExpiryMs { get; }
 
         public JwtSettings()
         {
             var secret = Environment.GetEnvironmentVariable("JWT_SECRET")
                 ?? throw new InvalidOperationException("Failed to find JWT_SECRET definition");
-            var expiry = Environment.GetEnvironmentVariable("JWT_EXPIRY_MS")
+            var jwtExpiry = Environment.GetEnvironmentVariable("JWT_EXPIRY_MS")
                 ?? throw new InvalidOperationException("Failed to find JWT_EXPIRY_MS definition");
+            var jwtRefreshExpiry = Environment.GetEnvironmentVariable("JWT_REFRESH_EXPIRY_MS")
+                ?? throw new InvalidOperationException("Failed to find JWT_REFRESH_EXPIRY_MS definition");
 
             Secret = Encoding.ASCII.GetBytes(secret);
-            ExpiryMs = int.TryParse(expiry, NumberStyles.Integer, CultureInfo.InvariantCulture, out var expiryMs) && expiryMs > 0
-                ? expiryMs
+            JwtExpiryMs = int.TryParse(jwtExpiry, NumberStyles.Integer, CultureInfo.InvariantCulture, out var jwtExpiryMs) && jwtExpiryMs > 0
+                ? jwtExpiryMs
                 : throw new InvalidOperationException("Invalid value for JWT_EXPIRY_MS. Value has to be positive integer.");
+            JwtRefreshExpiryMs = int.TryParse(jwtRefreshExpiry, NumberStyles.Integer, CultureInfo.InvariantCulture, out var jwtRefreshExpiryMs) && jwtRefreshExpiryMs > 0
+                ? jwtRefreshExpiryMs
+                : throw new InvalidOperationException("Invalid value for JWT_REFRESH_EXPIRY_MS. Value has to be positive integer.");
         }
     }
 }

--- a/backend/DevUp/DevUp.Infrastructure.Postgres/JwtIdentity/Results/JwtLoginResult.cs
+++ b/backend/DevUp/DevUp.Infrastructure.Postgres/JwtIdentity/Results/JwtLoginResult.cs
@@ -2,8 +2,7 @@
 
 namespace DevUp.Infrastructure.Postgres.JwtIdentity.Results
 {
-    public class JwtLoginResult : LoginResult
+    public class JwtLoginResult : JwtResult, ILoginResult
     {
-        public string Token { get; init; }
     }
 }

--- a/backend/DevUp/DevUp.Infrastructure.Postgres/JwtIdentity/Results/JwtRefreshResult.cs
+++ b/backend/DevUp/DevUp.Infrastructure.Postgres/JwtIdentity/Results/JwtRefreshResult.cs
@@ -2,7 +2,7 @@
 
 namespace DevUp.Infrastructure.Postgres.JwtIdentity.Results
 {
-    public class JwtRegistrationResult : JwtResult, IRegistrationResult
+    public class JwtRefreshResult : JwtResult, IRefreshResult
     {
     }
 }

--- a/backend/DevUp/DevUp.Infrastructure.Postgres/JwtIdentity/Results/JwtResult.cs
+++ b/backend/DevUp/DevUp.Infrastructure.Postgres/JwtIdentity/Results/JwtResult.cs
@@ -1,0 +1,8 @@
+﻿namespace DevUp.Infrastructure.Postgres.JwtIdentity.Results
+{
+    public abstract class JwtResult
+    {
+        public string Token { get; init; }
+        public string RefreshToken { get; init; }
+    }
+}

--- a/backend/DevUp/DevUp.Infrastructure.Postgres/JwtIdentity/Stores/IRefreshTokenStore.cs
+++ b/backend/DevUp/DevUp.Infrastructure.Postgres/JwtIdentity/Stores/IRefreshTokenStore.cs
@@ -1,0 +1,12 @@
+﻿using DevUp.Infrastructure.Postgres.JwtIdentity.Dtos;
+using Microsoft.AspNetCore.Identity;
+
+namespace DevUp.Infrastructure.Postgres.JwtIdentity.Stores
+{
+    internal interface IRefreshTokenStore
+    {
+        public Task<IdentityResult> CreateAsync(RefreshTokenDto token, CancellationToken cancellationToken);
+        public Task<RefreshTokenDto> GetAsync(string token, CancellationToken cancellationToken);
+        public Task<IdentityResult> MarkAsUsed(RefreshTokenDto token, CancellationToken cancellationToken);
+    }
+}

--- a/backend/DevUp/DevUp.Infrastructure.Postgres/JwtIdentity/Stores/RefreshTokenStore.cs
+++ b/backend/DevUp/DevUp.Infrastructure.Postgres/JwtIdentity/Stores/RefreshTokenStore.cs
@@ -1,0 +1,89 @@
+﻿using System.Data;
+using Dapper;
+using DevUp.Infrastructure.Postgres.JwtIdentity.Dtos;
+using Microsoft.AspNetCore.Identity;
+
+namespace DevUp.Infrastructure.Postgres.JwtIdentity.Stores
+{
+    internal class RefreshTokenStore : IRefreshTokenStore
+    {
+        private readonly IDbConnection _connection;
+
+        public RefreshTokenStore(IDbConnection connection)
+        {
+            _connection = connection ?? throw new ArgumentNullException(nameof(connection));
+        }
+
+        public async Task<IdentityResult> CreateAsync(RefreshTokenDto token, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (token is null)
+                throw new ArgumentNullException(nameof(token));
+
+            _connection.Open();
+            using var transaction = _connection.BeginTransaction();
+            try
+            {
+                var devicesSql = @"INSERT INTO devices (id, name) VALUES (@Id, @Name) 
+                                   ON CONFLICT (id) DO UPDATE SET name = @Name";
+                var devicesAffectedRows = await _connection.ExecuteAsync(devicesSql, new { Id = token.Device.Id, Name = token.Device.Name });
+                if (devicesAffectedRows <= 0)
+                    throw new InvalidOperationException("Could not create device");
+
+                var refreshTokensSql = @"INSERT INTO refresh_tokens (token, jti, user_id, creation_date, expiry_date, device_id, used, invalidated)
+                        VALUES (@Token, @Jti, @UserId, @CreationDate, @ExpiryDate, @DeviceId, @Used, @Invalidated)";
+
+                var refreshTokenAffectedRows = await _connection.ExecuteAsync(refreshTokensSql, 
+                    new { Token = token.Token, Jti = token.Jti, UserId = token.UserId, CreationDate = token.CreationDate, ExpiryDate = token.ExpiryDate, DeviceId = token.Device.Id, Used = token.Used, Invalidated = token.Invalidated });
+                if (refreshTokenAffectedRows <= 0)
+                    throw new InvalidOperationException("Could not create refresh token");
+
+                transaction.Commit();
+                return IdentityResult.Success;
+            }
+            catch (Exception exception)
+            {
+                transaction.Rollback();
+                return IdentityResult.Failed(new IdentityError() { Description = exception.Message });
+            }
+            finally
+            {
+                _connection.Close();
+            }
+        }
+
+        public async Task<RefreshTokenDto> GetAsync(string token, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (string.IsNullOrWhiteSpace(token))
+                throw new ArgumentNullException(nameof(token));
+
+            var sql = @"SELECT rt.token Token, rt.jti Jti, rt.user_id UserId, rt.creation_date CreationDate, rt.expiry_date ExpiryDate, rt.device_id DeviceId, rt.used Used, rt.invalidated Invalidated, d.id Id, d.name Name
+                        FROM refresh_tokens rt
+                        INNER JOIN devices d ON rt.device_id = d.id
+                        WHERE rt.token = @Token";
+
+            return (await _connection.QueryAsync<RefreshTokenDto, DeviceDto, RefreshTokenDto>(sql, (refreshTokenDto, device) =>
+            {
+                refreshTokenDto.Device = device;
+                return refreshTokenDto;
+            }, new { Token = token }, splitOn: "Id")).Single();
+        }
+
+        public async Task<IdentityResult> MarkAsUsed(RefreshTokenDto token, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (token is null)
+                throw new ArgumentNullException(nameof(token));
+
+            var sql = @"UPDATE refresh_tokens
+                        SET used = TRUE
+                        WHERE token = @Token";
+
+            var affectedRows = await _connection.ExecuteAsync(sql, new { Token = token.Token });
+            return affectedRows >= 0
+                ? IdentityResult.Success
+                : IdentityResult.Failed(new IdentityError() { Description = $"Failed to mark refresh token as used." });
+        }
+    }
+}

--- a/backend/DevUp/DevUp.Infrastructure.Postgres/JwtIdentity/Stores/UserStore.cs
+++ b/backend/DevUp/DevUp.Infrastructure.Postgres/JwtIdentity/Stores/UserStore.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Identity;
 
 namespace DevUp.Infrastructure.Postgres.JwtIdentity.Stores
 {
-    internal class UserStore : IUserStore<UserDto>, IUserPasswordStore<UserDto>
+    internal class UserStore : IUserStore<UserDto>, IUserPasswordStore<UserDto>, IUserAuthenticationTokenStore<UserDto>
     {
         private readonly IDbConnection _connection;
 
@@ -167,6 +167,21 @@ namespace DevUp.Infrastructure.Postgres.JwtIdentity.Stores
         {
             _connection.Close();
             _connection.Dispose();
+        }
+
+        public Task SetTokenAsync(UserDto user, string loginProvider, string name, string value, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task RemoveTokenAsync(UserDto user, string loginProvider, string name, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<string> GetTokenAsync(UserDto user, string loginProvider, string name, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/backend/DevUp/DevUp.Infrastructure.Postgres/Migrations/AddDevicesTable_2022051600002.cs
+++ b/backend/DevUp/DevUp.Infrastructure.Postgres/Migrations/AddDevicesTable_2022051600002.cs
@@ -1,0 +1,28 @@
+﻿using FluentMigrator;
+
+namespace DevUp.Infrastructure.Postgres.Migrations
+{
+    [Migration(2022050100002)]
+    public class AddDevicesTable_2022051600002 : Migration
+    {
+        public override void Up()
+        {
+            Create.Table("devices")
+                .WithColumn("id").AsString().NotNullable().PrimaryKey()
+                .WithColumn("name").AsString();
+
+            Create.ForeignKey()
+                .FromTable("refresh_tokens").ForeignColumn("device_id")
+                .ToTable("devices").PrimaryColumn("id");
+        }
+
+        public override void Down()
+        {
+            Delete.ForeignKey()
+                .FromTable("refresh_tokens").ForeignColumn("device_id")
+                .ToTable("devices").PrimaryColumn("id");
+
+            Delete.Table("devices");
+        }
+    }
+}

--- a/backend/DevUp/DevUp.Infrastructure.Postgres/Migrations/AddRefreshTokenTable_2022051600001.cs
+++ b/backend/DevUp/DevUp.Infrastructure.Postgres/Migrations/AddRefreshTokenTable_2022051600001.cs
@@ -1,0 +1,34 @@
+﻿using FluentMigrator;
+
+namespace DevUp.Infrastructure.Postgres.Migrations
+{
+    [Migration(2022050100001)]
+    public class AddRefreshTokenTable_2022051600001 : Migration
+    {
+        public override void Up()
+        {
+            Create.Table("refresh_tokens")
+                .WithColumn("token").AsAnsiString().PrimaryKey()
+                .WithColumn("jti").AsString().NotNullable()
+                .WithColumn("user_id").AsGuid()
+                .WithColumn("creation_date").AsDateTime2()
+                .WithColumn("expiry_date").AsDateTime2()
+                .WithColumn("device_id").AsString()
+                .WithColumn("used").AsBoolean()
+                .WithColumn("invalidated").AsBoolean();
+
+            Create.ForeignKey()
+                .FromTable("refresh_tokens").ForeignColumn("user_id")
+                .ToTable("users").PrimaryColumn("id");
+        }
+
+        public override void Down()
+        {
+            Delete.ForeignKey()
+                .FromTable("refresh_tokens").ForeignColumn("user_id")
+                .ToTable("users").PrimaryColumn("id");
+
+            Delete.Table("refresh_tokens");
+        }
+    }
+}

--- a/backend/DevUp/DevUp.Infrastructure/Documentation/SwaggerInstaller.cs
+++ b/backend/DevUp/DevUp.Infrastructure/Documentation/SwaggerInstaller.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
 
@@ -10,6 +13,10 @@ namespace DevUp.Infrastructure.Documentation
         {
             services.AddSwaggerGen(options =>
             {
+                var docName = $"{Assembly.GetEntryAssembly().GetName().Name}.xml";
+                var docPath = Path.Combine(AppContext.BaseDirectory, docName);
+                options.IncludeXmlComments(docPath);
+
                 options.AddSecurityDefinition("Bearer", new()
                 {
                     Name = "Authorization",

--- a/backend/DevUp/docker-compose.yml
+++ b/backend/DevUp/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     environment:
       JWT_SECRET: 2r5u8x/A?D(G-KaPdSgVkYp3s6v9y$B&
       JWT_EXPIRY_MS: 300000
+      JWT_REFRESH_EXPIRY_MS: 600000
       DB_CONNECTION_STRING: "host=postgres;port=5432;database=postgres;username=postgres;password=pass"
     depends_on:
       - postgres


### PR DESCRIPTION
- [x] added /refresh endpoint that allows to refresh tokens without the need for user to retype login/password
- [x] swagger will use xml comments to generate api doc
  - [x] added examples over /register, /login, /refresh
- [x] introduced concept of "devices" so that tokens will be valid only on the device that actually issued them
  - [x] added `Device` to register and login request dtos
- [x] added base classes for dtos/exceptions that share the same resultsn