### PR TITLE
Refactor devices

### DIFF
--- a/backend/DevUp/src/DevUp.Api.Contracts/V1/Identity/Requests/DeviceRequest.cs
+++ b/backend/DevUp/src/DevUp.Api.Contracts/V1/Identity/Requests/DeviceRequest.cs
@@ -3,7 +3,7 @@
     public class DeviceRequest
     {
         /// <example>b691b7a8-b251-4b11-8034-f3a0a154dffe</example>
-        public string Id { get; init; }
+        public Guid Id { get; init; }
         /// <example>iPhone (John)</example>
         public string Name { get; init; }
     }

--- a/backend/DevUp/src/DevUp.Application/Identity/Commands/Handlers/LoginUserCommandHandler.cs
+++ b/backend/DevUp/src/DevUp.Application/Identity/Commands/Handlers/LoginUserCommandHandler.cs
@@ -23,7 +23,7 @@ namespace DevUp.Application.Identity.Commands.Handlers
         {
             var username = new Username(request.Username);
             var password = new Password(request.Password);
-            var device = new Device(new DeviceId(request.DeviceId), request.DeviceName);
+            var device = new Device(new(request.DeviceId), new(request.DeviceName));
 
             var identityResult = await _identityService.LoginAsync(username, password, device, cancellationToken);
             var tokenPair = _mapper.Map<TokenPair>(identityResult);

--- a/backend/DevUp/src/DevUp.Application/Identity/Commands/Handlers/RefreshUserCommandHandler.cs
+++ b/backend/DevUp/src/DevUp.Application/Identity/Commands/Handlers/RefreshUserCommandHandler.cs
@@ -23,7 +23,7 @@ namespace DevUp.Application.Identity.Commands.Handlers
         {
             var token = new Token(request.Token);
             var refreshToken = new RefreshToken(request.RefreshToken);
-            var device = new Device(new DeviceId(request.DeviceId), request.DeviceName);
+            var device = new Device(new(request.DeviceId), new(request.DeviceName));
 
             var identityResult = await _identityService.RefreshAsync(token, refreshToken, device, cancellationToken);
             var tokenPair = _mapper.Map<TokenPair>(identityResult);

--- a/backend/DevUp/src/DevUp.Application/Identity/Commands/Handlers/RegisterUserCommandHandler.cs
+++ b/backend/DevUp/src/DevUp.Application/Identity/Commands/Handlers/RegisterUserCommandHandler.cs
@@ -23,7 +23,7 @@ namespace DevUp.Application.Identity.Commands.Handlers
         {
             var username = new Username(request.Username);
             var password = new Password(request.Password);
-            var device = new Device(new DeviceId(request.DeviceId), request.DeviceName);
+            var device = new Device(new(request.DeviceId), new(request.DeviceName));
 
             var identityResult = await _identityService.RegisterAsync(username, password, device, cancellationToken);
             var tokenPair = _mapper.Map<TokenPair>(identityResult);

--- a/backend/DevUp/src/DevUp.Application/Identity/Commands/LoginUserCommand.cs
+++ b/backend/DevUp/src/DevUp.Application/Identity/Commands/LoginUserCommand.cs
@@ -6,7 +6,7 @@ namespace DevUp.Application.Identity.Commands
     {
         public string Username { get; init; }
         public string Password { get; init; }
-        public string DeviceId { get; init; }
+        public Guid DeviceId { get; init; }
         public string DeviceName { get; init; }
     }
 }

--- a/backend/DevUp/src/DevUp.Application/Identity/Commands/RefreshUserCommand.cs
+++ b/backend/DevUp/src/DevUp.Application/Identity/Commands/RefreshUserCommand.cs
@@ -6,7 +6,7 @@ namespace DevUp.Application.Identity.Commands
     {
         public string Token { get; init; }
         public string RefreshToken { get; init; }
-        public string DeviceId { get; init; }
+        public Guid DeviceId { get; init; }
         public string DeviceName { get; init; }
     }
 }

--- a/backend/DevUp/src/DevUp.Application/Identity/Commands/RegisterUserCommand.cs
+++ b/backend/DevUp/src/DevUp.Application/Identity/Commands/RegisterUserCommand.cs
@@ -6,7 +6,7 @@ namespace DevUp.Application.Identity.Commands
     {
         public string Username { get; init; }
         public string Password { get; init; }
-        public string DeviceId { get; init; }
+        public Guid DeviceId { get; init; }
         public string DeviceName { get; init; }
     }
 }

--- a/backend/DevUp/src/DevUp.Domain/Identity/Entities/Device.cs
+++ b/backend/DevUp/src/DevUp.Domain/Identity/Entities/Device.cs
@@ -1,12 +1,13 @@
-﻿using DevUp.Domain.Seedwork;
+﻿using DevUp.Domain.Identity.ValueObjects;
+using DevUp.Domain.Seedwork;
 
 namespace DevUp.Domain.Identity.Entities
 {
     public class Device : Entity<DeviceId>
     {
-        public string Name { get; }
+        public DeviceName Name { get; }
 
-        public Device(DeviceId id, string name)
+        public Device(DeviceId id, DeviceName name)
             : base(id)
         {
             Name = name;
@@ -14,7 +15,7 @@ namespace DevUp.Domain.Identity.Entities
 
         public override string ToString()
         {
-            return Name;
+            return Name.ToString();
         }
     }
 }

--- a/backend/DevUp/src/DevUp.Domain/Identity/Entities/DeviceId.cs
+++ b/backend/DevUp/src/DevUp.Domain/Identity/Entities/DeviceId.cs
@@ -5,21 +5,16 @@ namespace DevUp.Domain.Identity.Entities
 {
     public class DeviceId : EntityId
     {
-        public string Id { get; }
+        public Guid Id { get; }
 
-        public DeviceId(string id)
+        public DeviceId(Guid id)
         {
             Id = id;
         }
 
-        public DeviceId(Guid id)
-            : this(id.ToString())
-        {
-        }
-
         public override string ToString()
         {
-            return Id;
+            return Id.ToString();
         }
 
         public override bool Equals(EntityId other)

--- a/backend/DevUp/src/DevUp.Domain/Identity/ValueObjects/DeviceName.cs
+++ b/backend/DevUp/src/DevUp.Domain/Identity/ValueObjects/DeviceName.cs
@@ -4,7 +4,7 @@ using DevUp.Domain.Seedwork;
 
 namespace DevUp.Domain.Identity.ValueObjects
 {
-    public sealed class DeviceName : ValueObject
+    public class DeviceName : ValueObject
     {
         public string Value { get; }
 

--- a/backend/DevUp/src/DevUp.Domain/Identity/ValueObjects/DeviceName.cs
+++ b/backend/DevUp/src/DevUp.Domain/Identity/ValueObjects/DeviceName.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using DevUp.Domain.Identity.ValueObjects.Exceptions;
+using DevUp.Domain.Seedwork;
+
+namespace DevUp.Domain.Identity.ValueObjects
+{
+    public sealed class DeviceName : ValueObject
+    {
+        public string Value { get; }
+
+        public DeviceName(string name)
+        {
+            Validate(name);
+            Value = name;
+        }
+
+        private static void Validate(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                throw new EmptyDeviceNameException();
+        }
+
+        public override string ToString()
+        {
+            return Value;
+        }
+
+        protected override IEnumerable<object> GetEqualityComponents()
+        {
+            yield return Value;
+        }
+    }
+}

--- a/backend/DevUp/src/DevUp.Domain/Identity/ValueObjects/Exceptions/EmptyDeviceNameException.cs
+++ b/backend/DevUp/src/DevUp.Domain/Identity/ValueObjects/Exceptions/EmptyDeviceNameException.cs
@@ -1,0 +1,12 @@
+﻿using DevUp.Domain.Identity.Exceptions;
+
+namespace DevUp.Domain.Identity.ValueObjects.Exceptions
+{
+    public sealed class EmptyDeviceNameException : IdentityDataValidationException
+    {
+        public EmptyDeviceNameException()
+            : base("Device name cannot be empty.")
+        {
+        }
+    }
+}

--- a/backend/DevUp/src/DevUp.Infrastructure.Postgres/Identity/Dtos/DeviceDto.cs
+++ b/backend/DevUp/src/DevUp.Infrastructure.Postgres/Identity/Dtos/DeviceDto.cs
@@ -2,7 +2,7 @@
 {
     internal record DeviceDto
     {
-        public string Id { get; set; }
+        public Guid Id { get; set; }
         public string Name { get; set; }
     }
 }

--- a/backend/DevUp/src/DevUp.Infrastructure.Postgres/Identity/Dtos/RefreshTokenDto.cs
+++ b/backend/DevUp/src/DevUp.Infrastructure.Postgres/Identity/Dtos/RefreshTokenDto.cs
@@ -7,7 +7,7 @@
         public Guid UserId { get; set; }
         public DateTime CreationDate { get; set; }
         public DateTime ExpiryDate { get; set; }
-        public string DeviceId { get; set; }
+        public Guid DeviceId { get; set; }
         public bool Used { get; set; }
         public bool Invalidated { get; set; }
     }

--- a/backend/DevUp/src/DevUp.Infrastructure.Postgres/Identity/IdentityMappingProfile.cs
+++ b/backend/DevUp/src/DevUp.Infrastructure.Postgres/Identity/IdentityMappingProfile.cs
@@ -29,7 +29,7 @@ namespace DevUp.Infrastructure.Postgres.Identity
             CreateMap<UserDto, User>().ConvertUsing(s => new User(new(s.Id), new(s.Username)));
             CreateMap<RefreshTokenDto, RefreshTokenInfo>().ConvertUsing<RefreshTokenMapper>();
             CreateMap<UserDto, PasswordHash>().ConvertUsing(s => new PasswordHash(s.PasswordHash));
-            CreateMap<DeviceDto, Device>().ConvertUsing(s => new Device(new(s.Id), s.Name));
+            CreateMap<DeviceDto, Device>().ConvertUsing(s => new Device(new(s.Id), new(s.Name)));
         }
 
         private class RefreshTokenMapper : ITypeConverter<RefreshTokenDto, RefreshTokenInfo>

--- a/backend/DevUp/src/DevUp.Infrastructure.Postgres/Migrations/UseGuidTypeForDeviceId_2022101300001.cs
+++ b/backend/DevUp/src/DevUp.Infrastructure.Postgres/Migrations/UseGuidTypeForDeviceId_2022101300001.cs
@@ -1,0 +1,49 @@
+﻿using FluentMigrator;
+
+namespace DevUp.Infrastructure.Postgres.Migrations
+{
+    [Migration(2022101300001)]
+    public class UseGuidTypeForDeviceId_2022101300001 : Migration
+    {
+        public override void Up()
+        {
+            DeleteConstraints();
+
+            void AsGuid(string table, string column) 
+                => Execute.Sql($"ALTER TABLE {table} ALTER COLUMN {column} TYPE uuid USING {column}::uuid");
+            AsGuid("devices", "id");
+            AsGuid("refresh_tokens", "device_id");
+
+            RestoreConstraints();
+        }
+
+        public override void Down()
+        {
+            DeleteConstraints();
+
+            Alter.Table("devices").AlterColumn("id").AsString();
+            Alter.Table("refresh_tokens").AlterColumn("device_id").AsString();
+
+            RestoreConstraints();
+        }
+
+        private void DeleteConstraints()
+        {
+            Delete.ForeignKey()
+                .FromTable("refresh_tokens").ForeignColumn("device_id")
+                .ToTable("devices").PrimaryColumn("id");
+            Delete.PrimaryKey("PK_devices")
+                .FromTable("devices");
+        }
+
+        private void RestoreConstraints()
+        {
+            Create.PrimaryKey("PK_devices")
+                .OnTable("devices")
+                .Column("id");
+            Create.ForeignKey()
+                .FromTable("refresh_tokens").ForeignColumn("device_id")
+                .ToTable("devices").PrimaryColumn("id");
+        }
+    }
+}

--- a/backend/DevUp/tests/DevUp.Api.Tests.Integration/V1/Identity/IdentityControllerTests.cs
+++ b/backend/DevUp/tests/DevUp.Api.Tests.Integration/V1/Identity/IdentityControllerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
@@ -43,7 +44,7 @@ namespace DevUp.Api.Tests.Integration.V1.Identity
             {
                 Username = "BAD-",
                 Password = "i'm-G00d-and-$tr0ng-p4ssworD",
-                Device = new DeviceRequest() { Id = "i'm ok", Name = "i'm ok" }
+                Device = new DeviceRequest() { Id = Guid.NewGuid(), Name = "i'm ok" }
             };
 
             var result = await _apiClient.PostAsJsonAsync(Route.Api.V1.Identity.Register, invalidRequest);

--- a/backend/DevUp/tests/DevUp.Api.Tests.Integration/V1/Identity/IdentityFaker.cs
+++ b/backend/DevUp/tests/DevUp.Api.Tests.Integration/V1/Identity/IdentityFaker.cs
@@ -27,7 +27,7 @@ namespace DevUp.Api.Tests.Integration.V1.Identity
                 Password = Faker.Internet.Password(passwordLength, prefix: "lowUPP1$"),
                 Device = new DeviceRequest()
                 {
-                    Id = Faker.Random.Guid().ToString(),
+                    Id = Faker.Random.Guid(),
                     Name = RandomDeviceName()
                 }
             };

--- a/backend/DevUp/tests/DevUp.Domain.Tests.Unit/Identity/IdentityFaker.cs
+++ b/backend/DevUp/tests/DevUp.Domain.Tests.Unit/Identity/IdentityFaker.cs
@@ -37,7 +37,7 @@ namespace DevUp.Domain.Tests.Unit.Identity
             Password = new Password(Faker.Internet.Password());
             PasswordHash = new PasswordHash(Faker.Random.Hash());
             User = new User(UserId, Username);
-            DeviceId = new DeviceId(Faker.Random.Guid().ToString());
+            DeviceId = new DeviceId(Faker.Random.Guid());
             DeviceName = new DeviceName(RandomDeviceName());
             Device = new Device(DeviceId, DeviceName);
             Token = new Token(Regex.Replace("{header}.{payload}.{signature}", "{.+?}", _ => RandomString()));

--- a/backend/DevUp/tests/DevUp.Domain.Tests.Unit/Identity/IdentityFaker.cs
+++ b/backend/DevUp/tests/DevUp.Domain.Tests.Unit/Identity/IdentityFaker.cs
@@ -20,6 +20,7 @@ namespace DevUp.Domain.Tests.Unit.Identity
         public PasswordHash PasswordHash { get; }
         public User User { get; }
         public DeviceId DeviceId { get; }
+        public DeviceName DeviceName { get; }
         public Device Device { get; }
         public Token Token { get; }
         public TokenInfo TokenInfo { get; }
@@ -37,7 +38,8 @@ namespace DevUp.Domain.Tests.Unit.Identity
             PasswordHash = new PasswordHash(Faker.Random.Hash());
             User = new User(UserId, Username);
             DeviceId = new DeviceId(Faker.Random.Guid().ToString());
-            Device = new Device(DeviceId, RandomDeviceName());
+            DeviceName = new DeviceName(RandomDeviceName());
+            Device = new Device(DeviceId, DeviceName);
             Token = new Token(Regex.Replace("{header}.{payload}.{signature}", "{.+?}", _ => RandomString()));
             TokenInfo = new TokenInfo(Token, Faker.Random.Guid().ToString(), UserId, DeviceId, RandomDateRange(now, 1, now));
             RefreshToken = new RefreshToken(RandomString());

--- a/backend/DevUp/tests/DevUp.Domain.Tests.Unit/Identity/ValueObjects/DeviceNameTests.cs
+++ b/backend/DevUp/tests/DevUp.Domain.Tests.Unit/Identity/ValueObjects/DeviceNameTests.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using DevUp.Domain.Identity.ValueObjects;
+using DevUp.Domain.Identity.ValueObjects.Exceptions;
+using NUnit.Framework;
+
+namespace DevUp.Domain.Tests.Unit.Identity.ValueObjects
+{
+    public class DeviceNameTests
+    {
+        private class Dummy : DeviceName
+        {
+            public Dummy(string deviceName) : base(deviceName)
+            {
+            }
+
+            public new IEnumerable<object> GetEqualityComponents() => base.GetEqualityComponents();
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase(" ")]
+        public void Constructor_WhenGivenEmptyDeviceName_ThrowsEmptyDeviceNameException(string deviceName)
+        {
+            var exception = Assert.Throws<EmptyDeviceNameException>(() => new DeviceName(deviceName));
+        }
+
+        [Test]
+        public void Constructor_WhenGivenValidDeviceName_AssignsValueProperty()
+        {
+            const string value = "valid-device-name";
+            var deviceName = new DeviceName(value);
+            Assert.AreEqual(deviceName.Value, value);
+        }
+
+        [Test]
+        public void GetEqualityComponents_WhenCalled_ReturnsDeviceNameValue()
+        {
+            const string value = "valid-username";
+            var deviceName = new Dummy(value);
+
+            var result = deviceName.GetEqualityComponents();
+
+            Assert.That(result, Has.One.EqualTo(value));
+        }
+    }
+}


### PR DESCRIPTION
- [x] encapsulate device name concept in value object
- [x] only allow guid as device id
   - I was thinking about exposing endpoint that would generate unique id for the client, but that seem overly engineered as most (all?) frameworks atm are able to generate collision-safe uuids