### PR TITLE
Add Elasticsearch

### DIFF
--- a/backend/DevUp/devops/elasticsearch/elasticsearch.yml
+++ b/backend/DevUp/devops/elasticsearch/elasticsearch.yml
@@ -1,0 +1,5 @@
+network.host: 0.0.0.0
+discovery.type: single-node
+xpack.security.enabled: false
+xpack.security.autoconfiguration.enabled: false
+xpack.security.enrollment.enabled: false

--- a/backend/DevUp/devops/kibana/kibana.yml
+++ b/backend/DevUp/devops/kibana/kibana.yml
@@ -1,0 +1,4 @@
+server.host: "0.0.0.0"
+server.shutdownTimeout: "5s"
+elasticsearch.hosts: [ "http://localhost:9200" ]
+monitoring.ui.container.elasticsearch.enabled: true

--- a/backend/DevUp/devops/kibana/kibana.yml
+++ b/backend/DevUp/devops/kibana/kibana.yml
@@ -1,4 +1,4 @@
-server.host: "0.0.0.0"
-server.shutdownTimeout: "5s"
-elasticsearch.hosts: [ "http://localhost:9200" ]
+server.host: 0.0.0.0
+server.shutdownTimeout: 5s
+elasticsearch.hosts: [ "http://host.docker.internal:9200" ]
 monitoring.ui.container.elasticsearch.enabled: true

--- a/backend/DevUp/docker-compose.yml
+++ b/backend/DevUp/docker-compose.yml
@@ -69,6 +69,8 @@ services:
       - 5601:5601
     volumes:
       - ./devops/kibana/kibana.yml:/usr/share/kibana/config/kibana.yml
+    depends_on:
+      - elasticsearch
 
 volumes:
   prometheus_data: {}

--- a/backend/DevUp/docker-compose.yml
+++ b/backend/DevUp/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       dockerfile: src/DevUp.Api/Dockerfile
     depends_on:
       - postgres
+      - elasticsearch
 
   postgres:
     image: postgres:latest
@@ -52,5 +53,17 @@ services:
     depends_on:
       - prometheus
 
+  elasticsearch:
+    image: elasticsearch:8.5.2
+    restart: always
+    ports:
+      - 9200:9200
+    environment:
+      discovery.type: 'single-node'
+    volumes:
+      - elasticsearch_data:/usr/share/elasticsearch/data
+
+
 volumes:
   prometheus_data: {}
+  elasticsearch_data: {}

--- a/backend/DevUp/docker-compose.yml
+++ b/backend/DevUp/docker-compose.yml
@@ -62,8 +62,19 @@ services:
       discovery.type: 'single-node'
     volumes:
       - elasticsearch_data:/usr/share/elasticsearch/data
+      - certs:/usr/share/elasticsearch/config/certs
+
+  kibana:
+    image: kibana:8.5.2
+    restart: always
+    ports:
+      - 5601:5601
+    volumes:
+      - ./devops/kibana/kibana.yml:/usr/share/kibana/config/kibana.yml
+      - certs:/usr/share/kibana/config/certs
 
 
 volumes:
   prometheus_data: {}
   elasticsearch_data: {}
+  certs: {}

--- a/backend/DevUp/docker-compose.yml
+++ b/backend/DevUp/docker-compose.yml
@@ -58,11 +58,9 @@ services:
     restart: always
     ports:
       - 9200:9200
-    environment:
-      discovery.type: 'single-node'
     volumes:
+      - ./devops/elasticsearch/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
       - elasticsearch_data:/usr/share/elasticsearch/data
-      - certs:/usr/share/elasticsearch/config/certs
 
   kibana:
     image: kibana:8.5.2
@@ -71,10 +69,7 @@ services:
       - 5601:5601
     volumes:
       - ./devops/kibana/kibana.yml:/usr/share/kibana/config/kibana.yml
-      - certs:/usr/share/kibana/config/certs
-
 
 volumes:
   prometheus_data: {}
   elasticsearch_data: {}
-  certs: {}

--- a/backend/DevUp/src/DevUp.Api/appsettings.json
+++ b/backend/DevUp/src/DevUp.Api/appsettings.json
@@ -1,8 +1,17 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+  "Logger": {
+    "ExcludePaths": [ "/", "/metrics" ],
+    "ElasticsearchOptions": {
+      "Uri": "http://elasticsearch:9200"
+    },
+    "Serilog": {
+      "MinimumLevel": {
+        "Default": "Information",
+        "Override": {
+          "Microsoft": "Information",
+          "System": "Warning"
+        }
+      }
     }
   },
   "Authentication": {
@@ -19,9 +28,6 @@
     "AppTag": "devupapp",
     "EnvTag": "devupenv",
     "ServerTag": "devupserver"
-  },
-  "Elasticsearch": {
-    "Uri": "http://localhost:9200"
   },
   "AllowedHosts": "*"
 }

--- a/backend/DevUp/src/DevUp.Api/appsettings.json
+++ b/backend/DevUp/src/DevUp.Api/appsettings.json
@@ -20,5 +20,8 @@
     "EnvTag": "devupenv",
     "ServerTag": "devupserver"
   },
+  "Elasticsearch": {
+    "Uri": "http://localhost:9200"
+  },
   "AllowedHosts": "*"
 }

--- a/backend/DevUp/src/DevUp.Infrastructure/DevUp.Infrastructure.csproj
+++ b/backend/DevUp/src/DevUp.Infrastructure/DevUp.Infrastructure.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="8.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />

--- a/backend/DevUp/src/DevUp.Infrastructure/DevUp.Infrastructure.csproj
+++ b/backend/DevUp/src/DevUp.Infrastructure/DevUp.Infrastructure.csproj
@@ -11,7 +11,10 @@
     <PackageReference Include="App.Metrics.Formatters.Prometheus" Version="4.3.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="8.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
   </ItemGroup>
 

--- a/backend/DevUp/src/DevUp.Infrastructure/InfrastructureInstaller.cs
+++ b/backend/DevUp/src/DevUp.Infrastructure/InfrastructureInstaller.cs
@@ -15,7 +15,7 @@ namespace DevUp.Infrastructure
     {
         public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
         {
-            services.AddLogger();
+            services.AddLogger(configuration);
             services.AddHttpContextAccessor();
             services.AddScoped<ITokenStore, HttpContextTokenStore>();
             services.AddSwagger();

--- a/backend/DevUp/src/DevUp.Infrastructure/Logging/LoggerInstaller.cs
+++ b/backend/DevUp/src/DevUp.Infrastructure/Logging/LoggerInstaller.cs
@@ -1,8 +1,9 @@
-﻿using System;
+﻿using System.Linq;
 using DevUp.Infrastructure.Logging.Setup;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Serilog;
+using Serilog.Filters;
 using Serilog.Sinks.Elasticsearch;
 
 namespace DevUp.Infrastructure.Logging
@@ -11,11 +12,13 @@ namespace DevUp.Infrastructure.Logging
     {
         public static IServiceCollection AddLogger(this IServiceCollection services, IConfiguration configuration)
         {
-            var options = configuration.GetRequiredSection("Elasticsearch").Get<ElasticsearchOptions>();
-            var sinkOptions = new ElasticsearchSinkOptions(options.Uri)
+            var options = configuration.GetRequiredSection("Logger").Get<LoggerOptions>();
+            var sinkOptions = new ElasticsearchSinkOptions(options.ElasticsearchOptions.Uri)
             {
-                IndexFormat = $"devup-logs-{DateTime.UtcNow:yyyy-MM}",
-                AutoRegisterTemplate = true
+                IndexFormat = "devup-logs-{0:yyyy-MM}",
+                AutoRegisterTemplate = true,
+                AutoRegisterTemplateVersion = AutoRegisterTemplateVersion.ESv7,
+                TypeName = null
             };
 
             Log.Logger = new LoggerConfiguration()
@@ -24,6 +27,8 @@ namespace DevUp.Infrastructure.Logging
                 .Enrich.WithEnvironmentName()
                 .WriteTo.Console()
                 .WriteTo.Elasticsearch(sinkOptions)
+                .ReadFrom.Configuration(configuration, sectionName: "Logger:Serilog")
+                .Filter.ByExcluding(Matching.WithProperty<string>("RequestPath", rp => options.ExcludePaths.Any(ep => ep.EndsWith(rp))))
                 .CreateLogger();
 
             services.AddLogging(loggingBuilder => loggingBuilder.AddSerilog(dispose: true));

--- a/backend/DevUp/src/DevUp.Infrastructure/Logging/LoggerInstaller.cs
+++ b/backend/DevUp/src/DevUp.Infrastructure/Logging/LoggerInstaller.cs
@@ -1,12 +1,31 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System;
+using DevUp.Infrastructure.Logging.Setup;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Serilog;
+using Serilog.Sinks.Elasticsearch;
 
 namespace DevUp.Infrastructure.Logging
 {
     internal static class LoggerInstaller
     {
-        public static IServiceCollection AddLogger(this IServiceCollection services)
+        public static IServiceCollection AddLogger(this IServiceCollection services, IConfiguration configuration)
         {
+            var options = configuration.GetRequiredSection("Elasticsearch").Get<ElasticsearchOptions>();
+            var sinkOptions = new ElasticsearchSinkOptions(options.Uri)
+            {
+                IndexFormat = $"devup-logs-{DateTime.UtcNow:yyyy-MM}",
+                AutoRegisterTemplate = true
+            };
+
+            Log.Logger = new LoggerConfiguration()
+                .Enrich.FromLogContext()
+                .Enrich.WithMachineName()
+                .Enrich.WithEnvironmentName()
+                .WriteTo.Console()
+                .WriteTo.Elasticsearch(sinkOptions)
+                .CreateLogger();
+
             services.AddLogging(loggingBuilder => loggingBuilder.AddSerilog(dispose: true));
             return services;
         }

--- a/backend/DevUp/src/DevUp.Infrastructure/Logging/Setup/ElasticsearchOptions.cs
+++ b/backend/DevUp/src/DevUp.Infrastructure/Logging/Setup/ElasticsearchOptions.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace DevUp.Infrastructure.Logging.Setup
+{
+    internal sealed class ElasticsearchOptions
+    {
+        public Uri Uri { get; set; }
+    }
+}

--- a/backend/DevUp/src/DevUp.Infrastructure/Logging/Setup/LoggerOptions.cs
+++ b/backend/DevUp/src/DevUp.Infrastructure/Logging/Setup/LoggerOptions.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace DevUp.Infrastructure.Logging.Setup
+{
+    internal sealed class LoggerOptions
+    {
+        public ElasticsearchOptions ElasticsearchOptions { get; set; }
+        public IEnumerable<string> ExcludePaths { get; set; } = Enumerable.Empty<string>();
+    }
+}


### PR DESCRIPTION
Added [Serilog](url) sink that will log to [Elasticsearch](https://github.com/elastic/elasticsearch). Logs are accessible via [Kibana](https://github.com/elastic/kibana).

How to test:
1. Build & launch.
2. Make some dummy requests to the API, for example you can fetch http://localhost:5000/api/v1/teams couple of times.
3. Go to http://localhost:5601 where you should see Kibana dashboard. On the left menu, in the "Analytics" section, click on the "Discover" item. 
4. Click on "Create data view" button. Enter `devup` as a name and `devup-logs-*` as the index pattern and click on "Save data view to Kibana".
5. You should be able to see logs from the requests that you executed on step 2. If you'll make new requests to the API now, they should appear there as well.

If needed, Elasticsearch can be accessed at http://localhost:9200. You can see its stats on http://localhost:9200/_stats.